### PR TITLE
fix lint and syntax errors for Navi31 CI

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -139,8 +139,8 @@ class TestMatmulCuda(TestCase):
     @dtypes(torch.float16, torch.bfloat16, torch.float32)
     @parametrize("size", [100, 1000, 10000])
     def test_cublas_addmm(self, size: int, dtype: torch.dtype):
-        if TEST_WITH_ROCM and isRocmArchAnyOf(NAVI_ARCH) and 
-          getRocmVersion() < (6,4) and dtype == torch.float16 and size >= 10000:
+        if (TEST_WITH_ROCM and isRocmArchAnyOf(NAVI_ARCH) and
+                getRocmVersion() < (6, 4) and dtype == torch.float16 and size >= 10000):
             self.skipTest(f"failed on Navi for ROCm6.3 due to hipblas backend, dtype={dtype} and size={size}")
         self.cublas_addmm(size, dtype, False)
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1968,6 +1968,7 @@ def getRocmVersion() -> Tuple[int]:
     rocm_version = str(torch.version.hip)
     rocm_version = rocm_version.split("-")[0]    # ignore git sha
     rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
+    return rocm_version_tuple
 
 # Skips a test on CUDA if ROCm is available and its version is lower than requested.
 def skipIfRocmVersionLessThan(version=None):


### PR DESCRIPTION
Fixed:

- lint error (trailing whitespace)
- syntax error (if condition)
- logical error (missed return value)

tested 
